### PR TITLE
update wmi_exporter version from 0.7.0 to 0.10.2

### DIFF
--- a/package/windows/Dockerfile
+++ b/package/windows/Dockerfile
@@ -2,7 +2,7 @@ ARG SERVERCORE_VERSION
 
 FROM mcr.microsoft.com/windows/servercore:${SERVERCORE_VERSION} as download
 ENV ARCH=amd64
-ENV WMI_EXPORTER_ARCHIVER_VERSION 0.7.0
+ENV WMI_EXPORTER_ARCHIVER_VERSION 0.10.2
 
 SHELL ["powershell", "-NoLogo", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 


### PR DESCRIPTION
We are seeing a number of PLEG issues on Windows worker nodes related to having monitored enabled. Bumping to v0.10.2 as it is the latest version without any breaking changes noted. 

This goroutine leak could be the source of the container 

[v0.8.1](https://github.com/prometheus-community/windows_exporter/releases/tag/v0.8.1)
Fix resource leak leading to slow increase in memory usage over time [#376](https://github.com/prometheus-community/windows_exporter/pull/376)

[v0.8.0](https://github.com/prometheus-community/windows_exporter/releases/tag/v0.8.0)

> Perflib
> This release contains the first use of Perflib in the cpu collector to give a lower-overhead way of fetching data than WMI. If this works out well, we expect to convert a majority of the existing collectors to Perflib, which should alleviate a lot of the issues around WMI we've seen.